### PR TITLE
android CI: fix deployment of apk files

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -120,9 +120,7 @@ jobs:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
         run:  |
             qmake -r ${SOURCE_DIR}/qgroundcontrol.pro -spec android-clang CONFIG+=${BUILD_TYPE} CONFIG+=installer ANDROID_ABIS="${{ matrix.eabi }}"
-            make -j2 apk
-            mkdir ${{ runner.temp }}/shadow_build_dir/package
-            mv ${{ runner.temp }}/shadow_build_dir/android-build/build/outputs/apk/debug/android-build-debug.apk ${{ runner.temp }}/shadow_build_dir/package/${{ matrix.ARTIFACT }}
+            make -j2
 
       - name: ccache post-run
         run:  ccache -s

--- a/QGCPostLinkInstaller.pri
+++ b/QGCPostLinkInstaller.pri
@@ -57,10 +57,13 @@ installer {
     }
     AndroidBuild {
         _ANDROID_KEYSTORE_PASSWORD = $$(ANDROID_KEYSTORE_PASSWORD)
+        QMAKE_POST_LINK += && mkdir -p package
         isEmpty(_ANDROID_KEYSTORE_PASSWORD) {
-            message(Skipping androiddeployqt since keystore password is not available)
+            message(Keystore password not available - not signing package)
+            # This is for builds in forks and PR where the Android keystore password is not available
+            QMAKE_POST_LINK += && make apk
+            QMAKE_POST_LINK += && cp android-build/build/outputs/apk/debug/android-build-debug.apk package/QGroundControl$${ANDROID_TRUE_BITNESS}.apk
         } else {
-            QMAKE_POST_LINK += && mkdir -p package
             QMAKE_POST_LINK += && make apk_install_target INSTALL_ROOT=android-build
             QMAKE_POST_LINK += && androiddeployqt --verbose --input android-QGroundControl-deployment-settings.json --output android-build --release --sign $${SOURCE_DIR}/android/android_release.keystore QGCAndroidKeyStore --storepass $$(ANDROID_KEYSTORE_PASSWORD)
             QMAKE_POST_LINK += && cp android-build/build/outputs/apk/release/android-build-release-signed.apk package/QGroundControl$${ANDROID_TRUE_BITNESS}.apk


### PR DESCRIPTION
When building on the master branch, the android keystore password is available. Building on a pullrequest or in a forked repository, the android keystore password is not available.

With the current build structure the "package" directory is created twice when the android keystore password is available resulting in a clash and build failure.

I changed the build structure such that correct builds are created for the two cases with and without the android keystore password.


